### PR TITLE
Add environment output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,5 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Options:
 
 <!-- END bumpver update --help -->
 
-To help with shell script automatin, you can use `bumpver show --env`
+To help with shell script automation, you can use `bumpver show --env`.
 
 ```shell
 $ bumpver show -n --env

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ ERROR   - No patterns matched for file 'src/mymodule/utils.py'
 $ bumpver --help
 Usage: bumpver [OPTIONS] COMMAND [ARGS]...
 
-  Automatically update CalVer version strings in plaintext files.
+  Automatically update version strings in plaintext files.
 
 Options:
   --version      Show the version and exit.
@@ -590,6 +590,21 @@ Options:
 ```
 
 <!-- END bumpver update --help -->
+
+To help with shell script automatin, you can use `bumpver show --env`
+
+```shell
+$ bumpver show -n --env
+YEAR_Y=2020
+YEAR_G=
+...
+TAG=final
+...
+
+$ eval $(bumpver show -n --env)
+$ echo $TAG
+final
+```
 
 
 ### Part Overview

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -189,6 +189,15 @@ fetch_option = click.option(
 )
 
 
+env_option = click.option(
+    "-e",
+    "--env",
+    is_flag=True,
+    default=False,
+    help="Print output as environment variables",
+)
+
+
 def version_options(function: typ.Callable) -> typ.Callable:
     decorators = [
         click.option("--major", is_flag=True, default=False, help="Increment major component."),
@@ -413,7 +422,8 @@ def grep(
 @cli.command()
 @verbose_option
 @fetch_option
-def show(verbose: int = 0, fetch: bool = True) -> None:
+@env_option
+def show(verbose: int = 0, fetch: bool = True, env: bool = False) -> None:
     """Show current version of your project."""
     _configure_logging(verbose=max(_VERBOSE, verbose))
 
@@ -424,8 +434,13 @@ def show(verbose: int = 0, fetch: bool = True) -> None:
         sys.exit(1)
 
     cfg = _update_cfg_from_vcs(cfg, fetch)
-    click.echo(f"Current Version: {cfg.current_version}")
-    click.echo(f"PEP440         : {cfg.pep440_version}")
+    if env:
+        version_info = v2version.parse_version_info(cfg.current_version, cfg.version_pattern)
+        for k, v in version_info._asdict().items():
+            click.echo(f"{k.upper()}={v if v else ''}")
+    else:
+        click.echo(f"Current Version: {cfg.current_version}")
+        click.echo(f"PEP440         : {cfg.pep440_version}")
 
 
 def _colored_diff_lines(diff: str) -> typ.Iterable[str]:

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -436,8 +436,8 @@ def show(verbose: int = 0, fetch: bool = True, env: bool = False) -> None:
     cfg = _update_cfg_from_vcs(cfg, fetch)
     if env:
         version_info = v2version.parse_version_info(cfg.current_version, cfg.version_pattern)
-        for k, v in version_info._asdict().items():
-            click.echo(f"{k.upper()}={v if v else ''}")
+        for key, val in version_info._asdict().items():
+            click.echo(f"{key.upper()}={val if val else ''}")
     else:
         click.echo(f"Current Version: {cfg.current_version}")
         click.echo(f"PEP440         : {cfg.pep440_version}")

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -438,6 +438,8 @@ def show(verbose: int = 0, fetch: bool = True, env: bool = False) -> None:
         version_info = v2version.parse_version_info(cfg.current_version, cfg.version_pattern)
         for key, val in version_info._asdict().items():
             click.echo(f"{key.upper()}={val if val else ''}")
+        click.echo(f"CURRENT_VERSION={cfg.current_version}")
+        click.echo(f"PEP440_VERSION={cfg.pep440_version}")
     else:
         click.echo(f"Current Version: {cfg.current_version}")
         click.echo(f"PEP440         : {cfg.pep440_version}")

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -194,7 +194,7 @@ env_option = click.option(
     "--env",
     is_flag=True,
     default=False,
-    help="Print output as environment variables",
+    help="Print version state for use with shell scripts: eval $(bumpver show --env)",
 )
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -116,6 +116,17 @@ def test_version(runner):
     assert match
 
 
+def test_show_env(runner):
+    _add_project_files("README.md", "setup.cfg")
+
+    result = runner.invoke(cli.cli, ['init', "-vv"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli.cli, ['show', "-e"])
+    assert result.exit_code == 0
+    assert "TAG=alpha" in result.output
+
+
 def test_incr_default(runner):
     old_version = "v201709.1004-alpha"
 


### PR DESCRIPTION
Add `-e` or `--env` option to bumpver show to allow users to set environment variables based on the version. This allows user to add some logic in shell scripts around the versioning.

Example:

```bash
$ cat bv.sh
#!/bin/bash

if [ $1 == "beta" ]; then

    CMD="bumpver update -n --tag-num"

    eval $(bumpver show -e)

    if [ -z $PYTAG ]; then CMD="$CMD --tag beta"; fi
    if [ -z $PATCH ]; then CMD="$CMD --patch"; fi

    exec $CMD

fi
$ 
$ ./bv.sh beta
INFO    - fetching tags from remote (to turn off use: -n / --no-fetch)
INFO    - Old Version: 21.1
INFO    - New Version: 21.1.1b0
$ 
```