### PR TITLE
FIX: hg backend won't work with PYTHONDEBUG=y

### DIFF
--- a/src/bumpver/vcs.py
+++ b/src/bumpver/vcs.py
@@ -76,7 +76,7 @@ class VCSAPI:
         else:
             logger.debug(cmd_str)
         cmd_parts = shlex.split(cmd_str)
-        output_data: bytes = sp.check_output(cmd_parts, env=env, stderr=sp.STDOUT)
+        output_data: bytes = sp.check_output(cmd_parts, env=env, stderr=sp.PIPE)
 
         return output_data.decode("utf-8")
 


### PR DESCRIPTION
This is due to hg currently having a warning:
```
$ hg pull
/usr/lib/python3.9/importlib/util.py:245: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  self.__spec__.loader.exec_module(self)
```
and the has_remote function checking:

    if output.strip() == "":

It was making my tests fail locally. By moving stderr to `subprocess.PIPE`, stderr is still on the error object, so it's still possible to debug.
