### PR TITLE
 VCS configuration via command line parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
     - name: make test
       run: make test
 
+    - name: make test_compat
+      run: make test_compat
+
   build-macos:
 
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for https://github.com/mbarkhau/bumpver
 
+## BumpVer 2021.1114
+
+ - Add: [flags to override vcs options][github_i168] for `bumpver update`
+
+[github_i168]: https://github.com/mbarkhau/bumpver/issues/168
+
+Thank you to Timo Ludwig @timoludwig for this contribution.
+
+
 ## BumpVer 2021.1113
 
  - Add: [`--commit-message` argument][github_i162] for `bumpver update`

--- a/README.md
+++ b/README.md
@@ -564,30 +564,29 @@ Usage: bumpver update [OPTIONS]
   Update project files with the incremented version string.
 
 Options:
-  -d, --dry                     Display diff of changes, don't rewrite files.
-  -f, --fetch / -n, --no-fetch  Sync tags from remote origin.
-  -v, --verbose                 Control log level. -vv for debug level.
-  --allow-dirty                 Commit even when working directory is has
-                                uncomitted changes. (WARNING: The commit will
-                                still be aborted if there are uncomitted to
-                                files with version strings.
-
-  --set-version <VERSION>       Set version explicitly.
-  --date <ISODATE>              Set explicit date in format YYYY-0M-0D (e.g.
-                                2021-05-13).
-
-  --pin-date                    Leave date components unchanged.
-  --tag-num                     Increment release tag number (rc1, rc2,
-                                rc3..).
-
-  -t, --tag <NAME>              Override release tag of current_version. Valid
-                                options are: alpha, beta, rc, post, final.
-
-  -p, --patch                   Increment PATCH component.
-  -m, --minor                   Increment MINOR component.
-  --major                       Increment MAJOR component.
-  -c, --commit-message <TMPL>   Set commit message template.
-  --help                        Show this message and exit.
+  -d, --dry                       Display diff of changes, don't rewrite files.
+  -f, --fetch / -n, --no-fetch    Sync tags from remote origin.
+  -v, --verbose                   Control log level. -vv for debug level.
+  --allow-dirty                   Commit even when working directory is has
+                                  uncomitted changes. (WARNING: The commit will
+                                  still be aborted if there are uncomitted to
+                                  files with version strings.
+  --set-version <VERSION>         Set version explicitly.
+  --date <ISODATE>                Set explicit date in format YYYY-0M-0D (e.g.
+                                  2021-05-13).
+  --pin-date                      Leave date components unchanged.
+  --tag-num                       Increment release tag number (rc1, rc2,
+                                  rc3..).
+  -t, --tag <NAME>                Override release tag of current_version. Valid
+                                  options are: alpha, beta, rc, post, final.
+  -p, --patch                     Increment PATCH component.
+  -m, --minor                     Increment MINOR component.
+  --major                         Increment MAJOR component.
+  -c, --commit-message <TMPL>     Set commit message template.
+  --commit / --no-commit          Create a commit with all updated files.
+  --tag-commit / --no-tag-commit  Tag the newly created commit.
+  --push / --no-push              Push to the default remote.
+  --help                          Show this message and exit.
 ```
 
 <!-- END bumpver update --help -->
@@ -1015,6 +1014,17 @@ INFO    - git commit --message 'bump version to 2020.1006'
 INFO    - git tag --annotate 2020.1006 --message 2020.1006
 INFO    - git push origin --follow-tags 2020.1006 HEAD
 ```
+
+It's also possible to override the config values by passing the following command line flags to `bumpver update`:
+
+|       Flag        |                 Override config                 |
+|-------------------|-------------------------------------------------|
+| `--commit`        | `commit = True`                                 |
+| `--no-commit`     | `commit = False`, `tag = False`, `push = False` |
+| `--tag-commit`    | `tag = True`                                    |
+| `--no-tag-commit` | `tag = False`                                   |
+| `--push`          | `push = True`                                   |
+| `--no-push`       | `push = False`                                  |
 
 ### Custom Commit Message
 

--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ INFO    - git tag --annotate 2020.1006 --message 2020.1006
 INFO    - git push origin --follow-tags 2020.1006 HEAD
 ```
 
-It's also possible to override the config values by passing the following command line flags to `bumpver update`:
+You can also override the config values by passing these command line flags to `bumpver update`:
 
 |       Flag        |                 Override config                 |
 |-------------------|-------------------------------------------------|
@@ -1025,6 +1025,7 @@ It's also possible to override the config values by passing the following comman
 | `--no-tag-commit` | `tag = False`                                   |
 | `--push`          | `push = True`                                   |
 | `--no-push`       | `push = False`                                  |
+
 
 ### Custom Commit Message
 
@@ -1049,6 +1050,7 @@ INFO    - New Version: 1.2.0
 INFO    - git commit --message '[final-version] 1.2.0b2 -> 1.2.0'
 ...
 ```
+
 
 ## Contributors
 

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -678,27 +678,27 @@ def _update_cfg_from_vcs(cfg: config.Config, fetch: bool) -> config.Config:
 
 
 def _parse_vcs_options(
-    cfg   : config.Config,
-    commit: typ.Optional[bool] = None,
-    tag   : typ.Optional[bool] = None,
-    push  : typ.Optional[bool] = None,
+    cfg       : config.Config,
+    commit    : typ.Optional[bool] = None,
+    tag_commit: typ.Optional[bool] = None,
+    push      : typ.Optional[bool] = None,
 ) -> config.Config:
+    if commit is False and tag_commit:
+        raise ValueError("--no-commit and --tag-commit cannot be used at the same time")
+    if commit is False and push:
+        raise ValueError("--no-commit and --push cannot be used at the same time")
+
     if commit is not None:
-        if not commit:
-            if tag:
-                raise ValueError("--no-commit and --tag-commit cannot be used at the same time")
-            if push:
-                raise ValueError("--no-commit and --push cannot be used at the same time")
         cfg = cfg._replace(commit=commit)
-    if tag is not None:
-        if tag and not cfg.commit:
-            raise ValueError(
-                "--tag-commit requires the --commit flag if commit=False in the config file"
-            )
-        cfg = cfg._replace(tag=tag)
+
+    if not cfg.commit and tag_commit:
+        raise ValueError("--tag-commit requires either --commit or commit=True in your config")
+    if not cfg.commit and push:
+        raise ValueError("--push requires either --commit or commit=True in your config")
+
+    if tag_commit is not None:
+        cfg = cfg._replace(tag=tag_commit)
     if push is not None:
-        if push and not cfg.commit:
-            raise ValueError("--push requires the --commit flag if commit=False in the config file")
         cfg = cfg._replace(push=push)
     return cfg
 

--- a/src/bumpver/v2patterns.py
+++ b/src/bumpver/v2patterns.py
@@ -149,7 +149,7 @@ def _fmt_yy(year_y: FieldValue) -> str:
 
 
 def _fmt_0y(year_y: FieldValue) -> str:
-    return "{0:02}".format(int(str(year_y)[-2:]))
+    return f"{int(str(year_y)[-2:]):02}"
 
 
 def _fmt_gg(year_g: FieldValue) -> str:
@@ -157,31 +157,31 @@ def _fmt_gg(year_g: FieldValue) -> str:
 
 
 def _fmt_0g(year_g: FieldValue) -> str:
-    return "{0:02}".format(int(str(year_g)[-2:]))
+    return f"{int(str(year_g)[-2:]):02}"
 
 
 def _fmt_0m(month: FieldValue) -> str:
-    return "{0:02}".format(int(month))
+    return f"{int(month):02}"
 
 
 def _fmt_0d(dom: FieldValue) -> str:
-    return "{0:02}".format(int(dom))
+    return f"{int(dom):02}"
 
 
 def _fmt_00j(doy: FieldValue) -> str:
-    return "{0:03}".format(int(doy))
+    return f"{int(doy):03}"
 
 
 def _fmt_0w(week_w: FieldValue) -> str:
-    return "{0:02}".format(int(week_w))
+    return f"{int(week_w):02}"
 
 
 def _fmt_0u(week_u: FieldValue) -> str:
-    return "{0:02}".format(int(week_u))
+    return f"{int(week_u):02}"
 
 
 def _fmt_0v(week_v: FieldValue) -> str:
-    return "{0:02}".format(int(week_v))
+    return f"{int(week_v):02}"
 
 
 FormatterFunc = typ.Callable[[FieldValue], str]

--- a/src/bumpver/vcs.py
+++ b/src/bumpver/vcs.py
@@ -225,15 +225,16 @@ def commit(
     new_version   : str,
     commit_message: str,
 ) -> None:
-    for filepath in filepaths:
-        vcs_api.add(filepath)
+    if cfg.commit:
+        for filepath in filepaths:
+            vcs_api.add(filepath)
 
-    vcs_api.commit(commit_message)
+        vcs_api.commit(commit_message)
 
     if cfg.commit and cfg.tag:
         vcs_api.tag(new_version)
 
-    if cfg.commit and cfg.tag and cfg.push:
+    if cfg.commit and cfg.push:
         vcs_api.push(new_version)
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -691,18 +691,16 @@ def test_incorrect_vcs_option_tag_push(runner, caplog):
     result = runner.invoke(cli.cli, ['update', "-vv", "--tag-commit"])
     assert result.exit_code == 1
     assert len(caplog.records) == 1
-    assert (
-        "Invalid argument: --tag-commit requires the --commit flag if commit=False in the config file"
-        in caplog.records[0].message
+    expected = (
+        "Invalid argument: --tag-commit requires either --commit or commit=True in your config"
     )
+    assert expected in caplog.records[0].message
 
     result = runner.invoke(cli.cli, ['update', "-vv", "--push"])
     assert result.exit_code == 1
     assert len(caplog.records) == 2
-    assert (
-        "Invalid argument: --push requires the --commit flag if commit=False in the config file"
-        in caplog.records[1].message
-    )
+    expected = "Invalid argument: --push requires either --commit or commit=True in your config"
+    assert expected in caplog.records[1].message
 
 
 @pytest.mark.parametrize("version_pattern, cur_version, cur_pep440", DEFAULT_VERSION_PATTERNS)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -276,9 +276,9 @@ def _update_config_val(filename, **kwargs):
 
     new_cfg_text = old_cfg_text
     for key, val in kwargs.items():
-        replacement = "{} = {}".format(key, val)
+        replacement = f"{key} = {val}"
         if replacement not in new_cfg_text:
-            pattern      = r"^{} = .*$".format(key)
+            pattern      = fr"^{key} = .*$"
             new_cfg_text = re.sub(pattern, replacement, new_cfg_text, flags=re.MULTILINE)
             assert old_cfg_text != new_cfg_text
 


### PR DESCRIPTION
This PR adds the feature suggested in #168:

- Add the following flags to the `bumpver update` command:
    * `--commit` / `--no-commit`
    * `--tag-commit` / `--no-tag-commit`
    * `--push` / `--no-push`
- Add test cases for these flags including checks for incorrect usage
- Document new flags in README

I waived short options because `-c`, `-t` and `-p` are already in use and I couldn't think of other letters which don't lead to confusion.

When setting up my dev environment, I got a few pylint errors which are due to a new warning class introduced in [Pylint 2.11](https://pylint.pycqa.org/en/latest/whatsnew/2.11.html). I fixed them by converting a few `.format()` calls to f-strings. I was a little bit confused because the library claims to support Python 2.7, but f-strings don't work there, do they? But I found several other occurrences of f-strings, so I thought it might be fine to convert the old syntax.

@mbarkhau thanks in advance for your feedback!