### PR TITLE
Fix incorrect version comparison when updating from vcs tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for https://github.com/mbarkhau/bumpver
 
+## BumpVer 2022.1116
+
+ - Fix: [incorrect version comparison when updating from vcs tag][gh_i174].
+
+   When comparing the updated version to the latest vcs tag,
+   an insufficient string comparison was used instead of
+   comparing the parsed versions.
+
+[gh_i174]: https://github.com/mbarkhau/bumpver/issues/174
+
+
 ## BumpVer 2022.1115
 
  - Fix: [use default date values][gh_i172].
@@ -14,7 +25,7 @@
    Thank you [Benjamin Depardon (@bdepardo)][gh_bdepardo] for
    finding and reporting this issue.
 
-[gh_i168]: https://github.com/mbarkhau/bumpver/issues/172
+[gh_i172]: https://github.com/mbarkhau/bumpver/issues/172
 [gh_bdepardo]: https://github.com/bdepardo
 
 

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -665,7 +665,7 @@ def _update_cfg_from_vcs(cfg: config.Config, fetch: bool) -> config.Config:
         return cfg
     else:
         latest_version_pep440 = version.to_pep440(latest_version_tag)
-        if latest_version_tag <= cfg.current_version:
+        if version.parse_version(latest_version_tag) <= version.parse_version(cfg.current_version):
             # current_version already newer/up-to-date
             return cfg
         else:


### PR DESCRIPTION
This fixes the problem that the vcs tag was incorrectly determined to be newer than the updated version.

Thanks @mbarkhau, your suggestion worked absolutely as expected!

Fixes #174