### PR TITLE
Support for pre/post commit hooks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ exclude =
 
 
 [tool:pytest]
-addopts = --doctest-modules
+addopts = --doctest-modules --ignore test/fixtures/hooks --ignore compat_test/fixtures/hooks
 
 
 [bumpver]

--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -807,11 +807,13 @@ def _sub_msg_template(message: str) -> str:
 @click.option(
     "--pre-commit-hook",
     type=click.Path(exists=True),
+    metavar="<PATH>",
     help="Custom script that runs before the commit step",
 )
 @click.option(
     "--post-commit-hook",
     type=click.Path(exists=True),
+    metavar="<PATH>",
     help="Custom script that runs after the commit step is completed",
 )
 def update(

--- a/src/bumpver/config.py
+++ b/src/bumpver/config.py
@@ -430,7 +430,7 @@ def _parse_config(raw_cfg: RawConfig) -> Config:
         raise ValueError("Invalid value for tag_scope")
 
     if pre_commit_hook and not pl.Path(pre_commit_hook).exists():
-        errmsg = f"Invalid value for pre_commit_hook: path '{pre_commit_hook}' does not exist"
+        errmsg = f"Invalid value for pre_commit_hook: Path '{pre_commit_hook}' does not exist"
         raise ValueError(errmsg)
 
     if post_commit_hook and not pl.Path(post_commit_hook).exists():

--- a/src/bumpver/hooks.py
+++ b/src/bumpver/hooks.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import logging
+import subprocess as sp
+
+import pathlib2 as pl
+
+logger = logging.getLogger("bumpver.hooks")
+
+
+def run(path: str, old_version: str, new_version: str) -> None:
+    env = dict(os.environ, BUMPVER_OLD_VERSION=old_version, BUMPVER_NEW_VERSION=new_version)
+
+    try:
+        # Python2 compatibility
+        # pylint:disable=consider-using-with
+        proc = sp.Popen(str(pl.Path(path).absolute()), env=env, stdout=sp.PIPE, stderr=sp.PIPE)
+        if proc.stdout is not None:
+            with proc.stdout as out:
+                for line in iter(out.readline, b''):
+                    logger.info(f"\t{line.decode('utf8').strip()}")
+        if proc.stderr is not None:
+            with proc.stderr as err:
+                for line in iter(err.readline, b''):
+                    logger.error(f"\t{line.decode('utf8').strip()}")
+        proc.wait()
+    except IOError as err:
+        logger.error(f"\t{err}")
+        logger.error("Script exited with error. Stopping")
+        sys.exit(1)
+
+    if proc.returncode != 0:
+        logger.error("Script exited with an error. Stopping")
+        sys.exit(1)

--- a/src/bumpver/hooks.py
+++ b/src/bumpver/hooks.py
@@ -26,7 +26,7 @@ def run(path: str, old_version: str, new_version: str) -> None:
         proc.wait()
     except IOError as err:
         logger.error(f"\t{err}")
-        logger.error("Script exited with error. Stopping")
+        logger.error("Script exited with an error. Stopping")
         sys.exit(1)
 
     if proc.returncode != 0:

--- a/src/bumpver/vcs.py
+++ b/src/bumpver/vcs.py
@@ -24,6 +24,7 @@ import logging
 import tempfile
 import subprocess as sp
 
+from . import hooks
 from . import config
 
 logger = logging.getLogger("bumpver.vcs")
@@ -273,10 +274,18 @@ def commit(
     tag_message   : str,
 ) -> None:
     if cfg.commit:
+        if cfg.pre_commit_hook:
+            logger.info(f"Run pre-commit hook: {cfg.pre_commit_hook}")
+            hooks.run(cfg.pre_commit_hook, cfg.current_version, new_version)
+
         for filepath in filepaths:
             vcs_api.add(filepath)
 
         vcs_api.commit(commit_message)
+
+        if cfg.post_commit_hook:
+            logger.info(f"Run post-commit hook: {cfg.post_commit_hook}")
+            hooks.run(cfg.post_commit_hook, cfg.current_version, new_version)
 
     if cfg.commit and cfg.tag:
         vcs_api.tag(tag_name=new_version, tag_message=tag_message)

--- a/test/fixtures/hooks/post_commit_hook.py
+++ b/test/fixtures/hooks/post_commit_hook.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from os import environ
+
+print("I'm a post commit hook. The new version is: " + environ.get('BUMPVER_NEW_VERSION', ''))

--- a/test/fixtures/hooks/pre_commit_hook.py
+++ b/test/fixtures/hooks/pre_commit_hook.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from os import environ
+
+print("I'm a pre commit hook. The old version was: " + environ.get('BUMPVER_OLD_VERSION', ''))

--- a/test/fixtures/hooks/pre_commit_hook_fail.py
+++ b/test/fixtures/hooks/pre_commit_hook_fail.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+exit(1)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,9 +7,11 @@ from __future__ import unicode_literals
 import io
 import os
 import re
+import stat
 import time
 import shlex
 import shutil
+import logging
 import datetime as dt
 import subprocess as sp
 
@@ -49,6 +51,16 @@ CALVER_TOML_FIXTURE = """
 PYPROJECT_TOML_FIXTURE = """
 [build-system]
 requires = ["setuptools", "wheel"]
+"""
+
+PRE_COMMIT_HOOK_FIXTURE = """#!/usr/bin/env python
+from os import environ
+print("I'm a pre commit hook. The old version was: " + environ.get('BUMPVER_OLD_VERSION'))
+"""
+
+POST_COMMIT_HOOK_FIXTURE = """#!/usr/bin/env python
+from os import environ
+print("I'm a post commit hook. The new version is: " + environ.get('BUMPVER_NEW_VERSION'))
 """
 
 ENV = {
@@ -304,6 +316,20 @@ def _add_project_files(*files):
     if "bumpver.toml" in files:
         with pl.Path("bumpver.toml").open(mode="wt", encoding="utf-8") as fobj:
             fobj.write(CALVER_TOML_FIXTURE)
+
+    if "pre_commit_hook.py" in files:
+        path = pl.Path("pre_commit_hook.py")
+        with path.open(mode="wt", encoding="utf-8") as fobj:
+            fobj.write(PRE_COMMIT_HOOK_FIXTURE)
+        pstat = path.stat()
+        path.chmod(pstat.st_mode | stat.S_IXUSR)
+
+    if "post_commit_hook.py" in files:
+        path = pl.Path("post_commit_hook.py")
+        with path.open(mode="wt", encoding="utf-8") as fobj:
+            fobj.write(POST_COMMIT_HOOK_FIXTURE)
+        pstat = path.stat()
+        path.chmod(pstat.st_mode | stat.S_IXUSR)
 
 
 def _update_config_val(filename, **kwargs):
@@ -1587,3 +1613,61 @@ def test_git_tag_scope_branch_version_conflict(runner, caplog, vcs_name):
 
     error_message = "Invariant violated: New version must be unique accross all branches"
     assert any(error_message in r.message for r in caplog.records)
+
+
+def test_commit_hook_execution(runner, caplog):
+    _add_project_files("pre_commit_hook.py", "post_commit_hook.py")
+    result = runner.invoke(cli.cli, ['init'])
+    assert result.exit_code == 0
+
+    _update_config_val("bumpver.toml", push="false")
+    _update_config_val("bumpver.toml", current_version='"0.1.0"')
+    _update_config_val("bumpver.toml", version_pattern='"MAJOR.MINOR.PATCH"')
+
+    _vcs_init("git", files=["bumpver.toml", "pre_commit_hook.py", "post_commit_hook.py"])
+
+    cmd = [
+        'update',
+        '--minor',
+        '--pre-commit-hook',
+        "pre_commit_hook.py",
+        '--post-commit-hook',
+        "post_commit_hook.py",
+    ]
+
+    caplog.set_level(logging.INFO)
+    result = runner.invoke(cli.cli, cmd)
+    assert result.exit_code == 0
+
+    pre_commit_msg = "I'm a pre commit hook. The old version was: 0.1.0"
+    assert any(pre_commit_msg in r.message for r in caplog.records)
+
+    post_commit_msg = "I'm a post commit hook. The new version is: 0.2.0"
+    assert any(post_commit_msg in r.message for r in caplog.records)
+
+
+def test_commit_hook_execution_fail(runner, caplog):
+    _add_project_files("pre_commit_hook.py")
+    result = runner.invoke(cli.cli, ['init'])
+    assert result.exit_code == 0
+
+    _update_config_val("bumpver.toml", push="false")
+
+    path = pl.Path("pre_commit_hook.py")
+    with path.open(mode="a", encoding="utf-8") as fobj:
+        fobj.write("exit(1)")
+
+    _vcs_init("git", files=["bumpver.toml", "pre_commit_hook.py"])
+
+    cmd = [
+        'update',
+        '--pre-commit-hook',
+        "pre_commit_hook.py",
+    ]
+
+    result = runner.invoke(cli.cli, cmd)
+    assert result.exit_code == 1
+    assert len(caplog.records) > 0
+
+    log_msg = caplog.records[0].message
+    assert "Script exited with an error. Stopping" in log_msg

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -459,3 +459,34 @@ def test_parse_invalid_version(tmpdir):
 
     cfg = config.parse(ctx)
     assert cfg is None
+
+
+def test_parse_commit_hooks():
+    hooks_path = util.FIXTURES_DIR / "hooks"
+
+    buf = mk_buf(
+        "\n".join(
+            [
+                MINIMAL_CFG_FIXTURE,
+                f"pre_commit_hook='{str(hooks_path)}/pre_commit_hook.py'",
+                f"post_commit_hook='{str(hooks_path)}/post_commit_hook.py'",
+            ]
+        )
+    )
+
+    raw_cfg = config._parse_cfg(buf)
+    cfg     = config._parse_config(raw_cfg)
+    assert cfg
+
+    assert cfg.pre_commit_hook  == f"{str(hooks_path)}/pre_commit_hook.py"
+    assert cfg.post_commit_hook == f"{str(hooks_path)}/post_commit_hook.py"
+
+
+def test_parse_commit_hooks_invalid():
+    buf = mk_buf(f"{MINIMAL_CFG_FIXTURE}\npre_commit_hook='foobar.py'")
+
+    raw_cfg = config._parse_cfg(buf)
+
+    with pytest.raises(ValueError) as err:
+        config._parse_config(raw_cfg)
+        assert "'foobar.py' does not exist" in err.message

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -482,8 +482,9 @@ def test_parse_commit_hooks():
     assert cfg.post_commit_hook == f"{str(hooks_path)}/post_commit_hook.py"
 
 
-def test_parse_commit_hooks_invalid():
-    buf = mk_buf(f"{MINIMAL_CFG_FIXTURE}\npre_commit_hook='foobar.py'")
+@pytest.mark.parametrize("hook", ['pre_commit_hook', 'post_commit_hook'])
+def test_parse_commit_hooks_invalid(hook):
+    buf = mk_buf(f"{MINIMAL_CFG_FIXTURE}\n{hook}='foobar.py'")
 
     raw_cfg = config._parse_cfg(buf)
 


### PR DESCRIPTION
Closes #178

Implements two new command line parameter `--pre-commit-hook`, `--post-commit-hook` and their config counterparts `pre_commit_hook`, `post_commit_hook`. 

- Paths must bei either absolute or relative to the working directory.
- If a hook exits with a `return_code != 0` bumpver will stop any further execution
- Two environment variables are set for the scripts: `BUMPVER_OLD_VERSION`, `BUMPVER_NEW_VERSION`
- Any output (`stdout`, `stderr`) will be piped to the bumpver log

Example output:
```
$ bumpver update --post-commit-hook changelog.sh
INFO    - fetching tags from remote (to turn off use: -n / --no-fetch)
INFO    - Old Version: 2023.1001-alpha
INFO    - New Version: 2023.1002-alpha
INFO    - git commit --message 'bump version 2023.1001-alpha -> 2023.1002-alpha'
INFO    - Run post-commit hook: changelog.sh
INFO    - 	Adding new item in CHANGES.md
INFO    - 	Commiting CHANGES.md
INFO    - git tag --annotate 2023.1002-alpha --message '2023.1002-alpha'
```

```
$bumpver update --post-commit-hook changelog.sh
INFO    - fetching tags from remote (to turn off use: -n / --no-fetch)
INFO    - Latest version from VCS tag: 2023.1002-alpha 
INFO    - Working dir version        : 2023.1002-alpha
INFO    - Old Version: 2023.1002-alpha
INFO    - New Version: 2023.1003-alpha
INFO    - git commit --message 'bump version 2023.1002-alpha -> 2023.1003-alpha'
INFO    - Run post-commit hook: changelog.sh
ERROR   - 	Environment variable FOOBAR is missing
ERROR   - Script exited with an error. Stopping
```

#### Checklist
- [x] Add tests
- [x] Run: make fmt lint mypy test test_compat
- [x] Update documentation