### PR TITLE
Pep440 version consistency

### DIFF
--- a/src/bumpver/cli.py
+++ b/src/bumpver/cli.py
@@ -326,7 +326,7 @@ def test(
 
         sys.exit(1)
 
-    pep440_version = version.to_pep440(new_version)
+    pep440_version = config.to_pep440(new_version, raw_pattern)
 
     click.echo(f"New Version: {new_version}")
     if new_version != pep440_version:
@@ -711,7 +711,7 @@ def _update_cfg_from_vcs(cfg: config.Config, fetch: bool) -> config.Config:
         logger.debug("no vcs tags found")
         return cfg
 
-    latest_version_pep440 = version.to_pep440(latest_version_tag)
+    latest_version_pep440 = config.to_pep440(latest_version_tag, cfg.version_pattern)
 
     scope_str = f"({cfg.tag_scope.value})" if not cfg.tag_scope == config.TagScope.DEFAULT else ""
     logger.info(f"Latest version from VCS tag: {latest_version_tag} {scope_str}")
@@ -931,8 +931,8 @@ def update(
         'old_version'       : old_version,
         'NEW_VERSION'       : new_version,
         'OLD_VERSION'       : old_version,
-        'new_version_pep440': version.to_pep440(new_version),
-        'old_version_pep440': version.to_pep440(old_version),
+        'new_version_pep440': config.to_pep440(new_version, cfg.version_pattern),
+        'old_version_pep440': config.to_pep440(old_version, cfg.version_pattern),
     }
 
     try_commit_message = commit_msg_template.format(**tag_and_commit_message_kwargs)

--- a/src/bumpver/config.py
+++ b/src/bumpver/config.py
@@ -391,6 +391,18 @@ def _parse_cfg_strings(raw_cfg: RawConfig, key: str, default: str) -> str:
     return raw_cfg.get(key, default)
 
 
+def to_pep440(version_str: str, pattern: str) -> str:
+    """Derive pep440 compliant version string from PyCalVer version string.
+
+    >>> to_pep440("v201811.7-beta", "vYYYYMM.INC1[-TAG]")
+    '201811.7b0'
+    """
+    if "{" in pattern or "}" in pattern:
+        return v1version.to_pep440(version_str, pattern)
+    else:
+        return v2version.to_pep440(version_str, pattern)
+
+
 def _parse_config(raw_cfg: RawConfig) -> Config:
     """Parse configuration which was loaded from an .ini/.cfg or .toml file."""
 
@@ -410,7 +422,7 @@ def _parse_config(raw_cfg: RawConfig) -> Config:
 
     _validate_version_with_pattern(current_version, version_pattern, is_new_pattern)
 
-    pep440_version = version.to_pep440(current_version)
+    pep440_version = to_pep440(current_version, version_pattern)
 
     file_patterns = _compile_file_patterns(raw_cfg, is_new_pattern)
 

--- a/src/bumpver/v1version.py
+++ b/src/bumpver/v1version.py
@@ -433,3 +433,19 @@ def incr(
         return None
     else:
         return new_version
+
+
+def to_pep440(version_str: str, pattern: str) -> str:
+    """Derive pep440 compliant version string from PyCalVer version string.
+
+    >>> to_pep440("v201811.7-beta", "vYYYYMM.INC1[-TAG]")
+    '201811.7b0'
+    """
+    v_info         = parse_version_info(version_str, pattern)
+    pep440_pattern = v1patterns.compile_pattern(pattern, "{pep440_version}").raw_pattern
+    try:
+        return format_version(v_info, pep440_pattern)
+    except TypeError:
+        # Not many v1 version patterns map nicely to a pep440 pattern, so fall back to the
+        # original pep440 conversion instead.
+        return str(version.parse_version(version_str))

--- a/src/bumpver/v1version.py
+++ b/src/bumpver/v1version.py
@@ -340,6 +340,11 @@ def format_version(vinfo: version.V1VersionInfo, raw_pattern: str) -> str:
     'v1.02.034'
     """
     full_pattern = raw_pattern
+
+    # remove regex chars
+    full_pattern = full_pattern.replace(r"^", r"")
+    full_pattern = full_pattern.replace(r"$", r"")
+
     for part_name, full_part_format in v1patterns.FULL_PART_FORMATS.items():
         full_pattern = full_pattern.replace("{" + part_name + "}", full_part_format)
 

--- a/src/bumpver/v2version.py
+++ b/src/bumpver/v2version.py
@@ -802,3 +802,14 @@ def incr(
         return None
     else:
         return new_version
+
+
+def to_pep440(version_str: str, pattern: str) -> str:
+    """Derive pep440 compliant version string from PyCalVer version string.
+
+    >>> to_pep440("v201811.7-beta", "vYYYYMM.INC1[-TAG]")
+    '201811.7b0'
+    """
+    v_info         = parse_version_info(version_str, pattern)
+    pep440_pattern = v2patterns.normalize_pattern(pattern, "{pep440_version}")
+    return format_version(v_info, pep440_pattern)

--- a/src/bumpver/version.py
+++ b/src/bumpver/version.py
@@ -176,12 +176,3 @@ def quarter_from_month(month: int) -> int:
     [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4]
     """
     return ((month - 1) // 3) + 1
-
-
-def to_pep440(version: str) -> str:
-    """Derive pep440 compliant version string from PyCalVer version string.
-
-    >>> to_pep440("v201811.0007-beta")
-    '201811.7b0'
-    """
-    return str(parse_version(version))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -516,3 +516,20 @@ def test_capitalisation(filename):
 
     finally:
         os.remove(filename)
+
+
+@pytest.mark.parametrize(
+    "version_str, pattern, expected",
+    [
+        ("v2017.54321"       , "vYYYY.BUILD", "2017.54321"),
+        ("v201808.0123-alpha", "vYYYY0M.0INC1[-TAG]", "201808.0123a0"),
+        ("v201811.0007-beta" , "vYYYY0M.000INC1[-TAG]", "201811.0007b0"),
+        ("v2020.1003-alpha"  , "vYYYY.BUILD[-TAG]", "2020.1003a0"),
+        ("v2020.1003-beta"   , "vYYYY.BUILD[-TAG]", "2020.1003b0"),
+        ("v2020.1003-dev"    , "vYYYY.BUILD[-TAG]", "2020.1003dev0"),
+        ("v2017q1.54321"     , "vYYYYqQ.BUILD", "2017q1.54321"),
+        ("1.2.3"             , "MAJOR.MINOR.PATCH", "1.2.3"),
+    ],
+)
+def test_to_pep440(version_str, pattern, expected):
+    assert config.to_pep440(version_str, pattern) == expected

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -294,20 +294,3 @@ WEEK_PATTERN_TEST_CASES = [
 @pytest.mark.parametrize("pattern, expected", WEEK_PATTERN_TEST_CASES)
 def test_is_valid_week_pattern(pattern, expected):
     assert v2version.is_valid_week_pattern(pattern) == expected
-
-
-PEP440_TEST_CASES = [
-    ("v2017.54321"       , "2017.54321"),
-    ("v201808.0123-alpha", "201808.123a0"),
-    ("v201811.0007-beta" , "201811.7b0"),
-    ("v2020.1003-alpha"  , "2020.1003a0"),
-    ("v2020.1003-beta"   , "2020.1003b0"),
-    ("v2020.1003-dev"    , "2020.1003.dev0"),
-    ("v2017q1.54321"     , "v2017q1.54321"),
-    ("1.2.3"             , "1.2.3"),
-]
-
-
-@pytest.mark.parametrize("version_str, expected", PEP440_TEST_CASES)
-def test_to_pep440(version_str, expected):
-    assert version.to_pep440(version_str) == expected


### PR DESCRIPTION
I have refactored some of the cli unit tests to check results from test and update (using --dry). I refactored the implementation so that test uses the same code to translate to pep440 as update.

However, I ran into a problem with this approach where some (most?) possible v1 patterns don't have a useful mapping to a pep440-compliant format, resulting in no handling whatsoever for such patterns. I note that using the {pep440_version} replacement pattern does not seem to work in these cases either. For now I have worked around this by falling back to the old pep440 handling in this specific case, which at least means those v1 patterns can be used without the {pep440_version} replacement pattern.

Ultimately I chose not to change the handling of update, because I expect that current users would be relying more heavily on those results, and changing those results is most likely to upset a few people. Please take a look and let me know your thoughts. I am interested to get a few opinions on this.