### PR TITLE
disable universal newlines

### DIFF
--- a/src/bumpver/v1rewrite.py
+++ b/src/bumpver/v1rewrite.py
@@ -94,7 +94,7 @@ def iter_rewritten(
     fobj: typ.IO[str]
 
     for file_path, pattern_strs in rewrite.iter_path_patterns_items(file_patterns):
-        with file_path.open(mode="rt", encoding="utf-8") as fobj:
+        with file_path.open(mode="rt", newline='', encoding="utf-8") as fobj:
             content = fobj.read()
 
         rfd = rfd_from_content(pattern_strs, new_vinfo, content)
@@ -112,7 +112,7 @@ def diff(
     fobj: typ.IO[str]
 
     for file_path, patterns in sorted(rewrite.iter_path_patterns_items(file_patterns)):
-        with file_path.open(mode="rt", encoding="utf-8") as fobj:
+        with file_path.open(mode="rt", newline='', encoding="utf-8") as fobj:
             content = fobj.read()
 
         has_updated_version = False
@@ -150,5 +150,5 @@ def rewrite_files(
 
     for file_data in iter_rewritten(file_patterns, new_vinfo):
         new_content = file_data.line_sep.join(file_data.new_lines)
-        with io.open(file_data.path, mode="wt", encoding="utf-8") as fobj:
+        with io.open(file_data.path, mode="wt", newline='', encoding="utf-8") as fobj:
             fobj.write(new_content)

--- a/src/bumpver/v2rewrite.py
+++ b/src/bumpver/v2rewrite.py
@@ -112,7 +112,7 @@ def iter_rewritten(
     fobj: typ.IO[str]
 
     for file_path, patterns in rewrite.iter_path_patterns_items(file_patterns):
-        with file_path.open(mode="rt", encoding="utf-8") as fobj:
+        with file_path.open(mode="rt", newline='', encoding="utf-8") as fobj:
             content = fobj.read()
 
         rfd = rfd_from_content(patterns, new_vinfo, content)
@@ -130,7 +130,7 @@ def diff(
     fobj: typ.IO[str]
 
     for file_path, patterns in sorted(rewrite.iter_path_patterns_items(file_patterns)):
-        with file_path.open(mode="rt", encoding="utf-8") as fobj:
+        with file_path.open(mode="rt", newline='', encoding="utf-8") as fobj:
             content = fobj.read()
 
         try:
@@ -163,5 +163,5 @@ def rewrite_files(
 
     for file_data in iter_rewritten(file_patterns, new_vinfo):
         new_content = file_data.line_sep.join(file_data.new_lines)
-        with io.open(file_data.path, mode="wt", encoding="utf-8") as fobj:
+        with io.open(file_data.path, mode="wt", newline='', encoding="utf-8") as fobj:
             fobj.write(new_content)


### PR DESCRIPTION
Hello,

On windows, bumpver ends up always rewriting files with '\r\n' endings due to universal newlines in text mode. The PR disables this.

In more detail, universal newline text mode always returns '\n' to the code, but ends up translating it to '\r\n' on write. This causes bumpver to fail to preserve the original newlines.