### PR TITLE
Use tomllib/tomli for TOML parsing

### DIFF
--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -11,7 +11,8 @@ pathlib2; python_version < "3.4"
 typing; python_version < "3.5"
 click<8.0; python_version < "3.6"
 click; python_version >= "3.6"
-toml
+toml; python_version < "3.7"
+tomli; python_version >= "3.7" and python_version < "3.11"
 lexid
 colorama>=0.4
 enum34; python_version < "3.4"

--- a/src/bumpver/config.py
+++ b/src/bumpver/config.py
@@ -11,7 +11,13 @@ import typing as typ
 import logging
 import configparser
 
-import toml
+try:
+    import tomllib  # Python 3.11+
+except ImportError:
+    try:
+        import tomli as tomllib  # Python 3.7+
+    except ImportError:
+        import toml as tomllib  # Python 2.7/3.6
 
 from bumpver import pathlib as pl
 
@@ -251,7 +257,7 @@ def _parse_cfg(cfg_buffer: typ.IO[str]) -> RawConfig:
 
 
 def _parse_toml(cfg_buffer: typ.IO[str]) -> RawConfig:
-    raw_full_cfg: typ.Any = toml.load(cfg_buffer)
+    raw_full_cfg: typ.Any = tomllib.loads(cfg_buffer.read())
     raw_cfg     : RawConfig
 
     if 'tool' in raw_full_cfg and 'bumpver' in raw_full_cfg['tool']:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -114,6 +114,27 @@ version_pattern = "vYYYY0M.BUILD[-TAG]"
 """
 
 
+PYPROJECT_TOML_WITH_DEPENDENCY_GROUPS_FIXTURE = """
+[dependency-groups]
+local = [
+    "packaging",
+]
+test = [
+    "pytest",
+    {include-group = "local"},
+]
+
+[tool.bumpver]
+current_version = "v2025.1131"
+version_pattern = "vYYYY.BUILD"
+
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+    'current_version = "{version}"',
+]
+"""
+
+
 def mk_buf(text):
     buf = io.StringIO()
     buf.write(text)
@@ -378,6 +399,19 @@ def test_parse_default_pattern():
     assert raw_patterns_by_filepath == {
         "pyproject.toml": [r'current_version = "v{year}q{quarter}.{build_no}"']
     }
+
+
+def test_parse_pyproject_toml_with_dependency_groups():
+    buf = mk_buf(PYPROJECT_TOML_WITH_DEPENDENCY_GROUPS_FIXTURE)
+
+    raw_cfg = config._parse_toml(buf)
+    cfg     = config._parse_config(raw_cfg)
+
+    assert cfg.current_version == "v2025.1131"
+    assert cfg.version_pattern == "vYYYY.BUILD"
+
+    raw_patterns_by_path = _parse_raw_patterns_by_filepath(cfg)
+    assert raw_patterns_by_path["pyproject.toml"] == ['current_version = "vYYYY.BUILD"']
 
 
 def test_parse_cfg_file(tmpdir):


### PR DESCRIPTION
Switch TOML parsing from `toml` to `tomllib`/`tomli` where available, while keeping `toml` as a fallback for Python 2.7/3.6. This fixes parsing of modern `pyproject.toml` files that use PEP 735 dependency groups with inline include tables, for example:

  ```toml
  [dependency-groups]
  test = [
      "pytest",
      {include-group = "local"},
  ]
```

Fixes #247.